### PR TITLE
:construction_worker: add dotnet-format actions

### DIFF
--- a/.github/workflows/format-pr-on-dotnet-format-command.yml
+++ b/.github/workflows/format-pr-on-dotnet-format-command.yml
@@ -1,0 +1,59 @@
+name: Format PR on '/dotnet format'
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  dotnet-format:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Check for command
+        id: command
+        uses: xt0rted/slash-command-action@v1
+        continue-on-error: true
+        with:
+          command: dotnet
+          reaction-type: "rocket"
+
+      - name: Get branch info
+        if: steps.command.outputs.command-name
+        id: comment-branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repo
+        if: steps.command.outputs.command-name
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.comment-branch.outputs.ref }}
+          persist-credentials: false
+
+      - name: Restore dotnet tools
+        if: steps.command.outputs.command-name
+        uses: xt0rted/dotnet-tool-restore@v1
+
+      - name: Run dotnet format
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format'
+        id: format
+        uses: xt0rted/dotnet-format@v1
+        with:
+          action: "fix"
+          only-changed-files: true
+
+      - name: Commit files
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m ':art: apply dotnet-format
+
+          Co-authored-by: ${{ github.event.comment.user.login }} <${{ github.event.comment.user.id }}+${{ github.event.comment.user.login }}@users.noreply.github.com>'
+
+      - name: Push changes
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          branch: ${{ steps.comment-branch.outputs.ref }}
+          github_token: ${{ secrets.DOTNET_FORMAT_PAT }}

--- a/.github/workflows/format-pr-on-dotnet-format-command.yml
+++ b/.github/workflows/format-pr-on-dotnet-format-command.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run dotnet format
         if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format'
         id: format
-        uses: xt0rted/dotnet-format@v1
+        uses: jfversluis/dotnet-format@v1.0.9
         with:
           action: "fix"
           only-changed-files: true

--- a/.github/workflows/format-pr-on-dotnet-format-command.yml
+++ b/.github/workflows/format-pr-on-dotnet-format-command.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   dotnet-format:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     if: ${{ github.event.issue.pull_request }}
     steps:
       - name: Check for command
@@ -37,11 +37,12 @@ jobs:
       - name: Run dotnet format
         if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format'
         id: format
-        uses: jfversluis/dotnet-format@v1.0.9
+        uses: eero-dev/dotnet-format@1.0.0
         with:
           action: "fix"
           only-changed-files: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          workspace: "src/Burser.sln"
 
       - name: Commit files
         if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'

--- a/.github/workflows/format-pr-on-dotnet-format-command.yml
+++ b/.github/workflows/format-pr-on-dotnet-format-command.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           action: "fix"
           only-changed-files: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit files
         if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'

--- a/.github/workflows/format-pr-on-dotnet-format-command.yml
+++ b/.github/workflows/format-pr-on-dotnet-format-command.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           action: "fix"
           only-changed-files: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit files
         if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'

--- a/.github/workflows/verify-formatting-on-pr.yml
+++ b/.github/workflows/verify-formatting-on-pr.yml
@@ -18,3 +18,4 @@ jobs:
         uses: jfversluis/dotnet-format@v1.0.9
         with:
           only-changed-files: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-formatting-on-pr.yml
+++ b/.github/workflows/verify-formatting-on-pr.yml
@@ -18,4 +18,4 @@ jobs:
         uses: jfversluis/dotnet-format@v1.0.9
         with:
           only-changed-files: true
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-formatting-on-pr.yml
+++ b/.github/workflows/verify-formatting-on-pr.yml
@@ -1,0 +1,20 @@
+name: Verify formatting on PRs
+on: pull_request
+
+jobs:
+  dotnet-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Add dotnet-format problem matcher
+        uses: xt0rted/dotnet-format-problem-matcher@v1
+
+      - name: Restore dotnet tools
+        uses: xt0rted/dotnet-tool-restore@v1
+
+      - name: Run dotnet format
+        uses: xt0rted/dotnet-format@v1
+        with:
+          only-changed-files: "true"

--- a/.github/workflows/verify-formatting-on-pr.yml
+++ b/.github/workflows/verify-formatting-on-pr.yml
@@ -15,6 +15,6 @@ jobs:
         uses: xt0rted/dotnet-tool-restore@v1
 
       - name: Run dotnet format
-        uses: xt0rted/dotnet-format@v1
+        uses: jfversluis/dotnet-format@v1.0.9
         with:
-          only-changed-files: "true"
+          only-changed-files: true

--- a/.github/workflows/verify-formatting-on-pr.yml
+++ b/.github/workflows/verify-formatting-on-pr.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   dotnet-format:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -15,7 +15,8 @@ jobs:
         uses: xt0rted/dotnet-tool-restore@v1
 
       - name: Run dotnet format
-        uses: jfversluis/dotnet-format@v1.0.9
+        uses: eero-dev/dotnet-format@1.0.0
         with:
           only-changed-files: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          workspace: "src/Burser.sln"

--- a/src/Burser/MauiProgram.cs
+++ b/src/Burser/MauiProgram.cs
@@ -11,7 +11,7 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .ConfigureFonts(fonts =>
             {
-                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+               fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 

--- a/src/Burser/MauiProgram.cs
+++ b/src/Burser/MauiProgram.cs
@@ -11,7 +11,7 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .ConfigureFonts(fonts =>
             {
-               fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 


### PR DESCRIPTION
Added actions enabling dotnet-format status checks.

On new PRs, an action verifies whether the changed files contain any formatting issues that need to be corrected before merging.

A separate action allows us to add a PR comment with content `/dotnet format`, which will generate a commit on the PR branch with formatting fixes.

Closes: #16